### PR TITLE
Set encoding for file with 'weird' character

### DIFF
--- a/lib/computering/dsl/command.rb
+++ b/lib/computering/dsl/command.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "bundler"
 
 module Computering::Dsl


### PR DESCRIPTION
The '⌘' character does not agree with US-ASCII encoding.
